### PR TITLE
Fixed compiler optimization setting

### DIFF
--- a/packages/contracts/truffle-config.js
+++ b/packages/contracts/truffle-config.js
@@ -16,10 +16,12 @@ module.exports = {
   compilers: {
     solc: {
       version: "0.6.12",
-      optimizer: {
-        enabled: true,
-        runs: 200
-      },
+      settings: {
+        optimizer: {
+          enabled: true,
+          runs: 200
+        },
+      }
     }
   },
   mocha: {


### PR DESCRIPTION
- Fixed truffle's compiler optimization setting

```javascript
compilers: {
     solc: {
       version: "0.6.12",
-      optimizer: {
-        enabled: true,
-        runs: 200
-      },
+      settings: {
+        optimizer: {
+          enabled: true,
+          runs: 200
+        },
+      }
     }
   },
```