### PR TITLE
Allow weighted votes

### DIFF
--- a/packages/contracts/contracts/VotingToken.sol
+++ b/packages/contracts/contracts/VotingToken.sol
@@ -12,12 +12,21 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 contract VotingToken is ERC721, Ownable {
     // keep track of total tokens
     uint256 public curTokenId = 1;
+    mapping(address => uint256) public weights;
+
     constructor() public ERC721("VotingToken", "VotingToken") Ownable() {}
 
     // give erc721 token to an address
-    function giveToken(address to) public onlyOwner {
-        _mint(to, curTokenId);
+    function giveToken(address _to, uint256 _weight) public onlyOwner {
+        require(_weight > 0 && _weight <= 100, "Error: weight range must be between 1 and 100");
+        _mint(_to, curTokenId);
+        weights[_to] = _weight;
         curTokenId += 1;
+    }
+
+    function getTokenWeight(address _key) external view returns (uint256) {
+        require(_key != address(0), "key cannot be zero address");
+        return weights[_key];
     }
 
     // how many tokens are allocated

--- a/packages/contracts/test/BatchProcessMessage.Test.ts
+++ b/packages/contracts/test/BatchProcessMessage.Test.ts
@@ -76,6 +76,7 @@ contract('Maci(BatchProcessMessage)', (accounts) => {
     const voteOptionTreeDepth = config.maci.merkleTrees.voteOptionTreeDepth // 2
     const voteOptionsMaxIndex = config.maci.voteOptionsMaxLeafIndex // 3
     const quadVoteTallyBatchSize = config.maci.quadVoteTallyBatchSize // 4
+    const weight = 2 // bnSqrt(BigNumber.from(2)) = 0x01, BigNumber
 
     const contractOwner = accounts[0]
     const coordinatorAddress = accounts[1]
@@ -176,7 +177,7 @@ contract('Maci(BatchProcessMessage)', (accounts) => {
             totalVoteWeight += BigInt(voteWeight) * BigInt(voteWeight)
             totalVotes += voteWeight
 
-            await votingToken.giveToken(voter.wallet)
+            await votingToken.giveToken(voter.wallet, weight)
             await votingToken.setApprovalForAll(cream.address, true, {
                 from: voter.wallet,
             })

--- a/packages/contracts/test/Cream.Test.ts
+++ b/packages/contracts/test/Cream.Test.ts
@@ -57,6 +57,7 @@ contract('Cream', (accounts) => {
     const coordinator = new Keypair(
         new PrivKey(BigInt(config.maci.coordinatorPrivKey))
     )
+    const weight = 2 // bnSqrt(BigNumber.from(2)) = 0x01, BigNumber
 
     // recipient index
     let recipient = 0
@@ -98,7 +99,7 @@ contract('Cream', (accounts) => {
     })
 
     beforeEach(async () => {
-        await votingToken.giveToken(voter)
+        await votingToken.giveToken(voter, weight)
         await votingToken.setApprovalForAll(cream.address, true, {
             from: voter,
         })
@@ -193,7 +194,7 @@ contract('Cream', (accounts) => {
             })
 
             // voter 2 deposit
-            await votingToken.giveToken(voter2)
+            await votingToken.giveToken(voter2, weight)
             await votingToken.setApprovalForAll(cream.address, true, {
                 from: voter2,
             })
@@ -250,7 +251,7 @@ contract('Cream', (accounts) => {
 
         // voter and bad user collude pattern
         it('should throw an error for more than two tokens holder', async () => {
-            await votingToken.giveToken(badUser)
+            await votingToken.giveToken(badUser, weight)
             await votingToken.setApprovalForAll(cream.address, true, {
                 from: badUser,
             })

--- a/packages/contracts/test/Cream.Test.ts
+++ b/packages/contracts/test/Cream.Test.ts
@@ -280,6 +280,36 @@ contract('Cream', (accounts) => {
             assert.equal(2, balance)
         })
 
+        it('should revert if weight is out of range > 10', async () => {
+            try {
+                await votingToken.giveToken(voter, 101, {
+                    from: contractOwner,
+                })
+            } catch (error) {
+                assert.equal(
+                    error.reason,
+                    'Error: weight range must be between 1 and 100'
+                )
+                return
+            }
+            assert.fail('Expected revert not received')
+        })
+
+        it('should revert if weight is out of range = 0', async () => {
+            try {
+                await votingToken.giveToken(voter, 0, {
+                    from: contractOwner,
+                })
+            } catch (error) {
+                assert.equal(
+                    error.reason,
+                    'Error: weight range must be between 1 and 100'
+                )
+                return
+            }
+            assert.fail('Expected revert not received')
+        })
+
         it('should throw an error for same commitment submittion', async () => {
             const deposit = createDeposit(rbigInt(31), rbigInt(31))
             await cream.deposit(toHex(deposit.commitment), { from: voter })

--- a/packages/contracts/test/CreamFactory.Test.ts
+++ b/packages/contracts/test/CreamFactory.Test.ts
@@ -33,6 +33,7 @@ contract('CreamFactory', (accounts) => {
     const coordinator = new Keypair(
         new PrivKey(BigInt(config.maci.coordinatorPrivKey))
     )
+    const weight = 2 // bnSqrt(BigNumber.from(2)) = 0x01, BigNumber
 
     before(async () => {
         creamFactory = await CreamFactory.deployed()
@@ -143,7 +144,7 @@ contract('CreamFactory', (accounts) => {
         })
 
         it('should be able to deploy another cream contract', async () => {
-            await votingToken.giveToken(voter)
+            await votingToken.giveToken(voter, weight)
             await votingToken.setApprovalForAll(creamAddress, true, {
                 from: voter,
             })

--- a/packages/contracts/test/E2E.Test.ts
+++ b/packages/contracts/test/E2E.Test.ts
@@ -284,23 +284,23 @@ contract('E2E', (accounts) => {
                 )
                 await letAllVoterSignUp2Maci(voterKeypairs)
 
-                // 1. vote 1 voice credit w/ original key pair
+                // 1. vote w/ original key pair
                 await letAllVotersVote(voterKeypairs, 3, undefined)
 
                 const newVoterKeypairs = [...Array(batchSize)].map(
                     (_) => new Keypair()
                 )
-                // 2. vote 1 voice credit w/ new key pair
+                // 2. vote w/ new key pair
                 await letAllVotersVote(voterKeypairs, 2, newVoterKeypairs)
 
-                // 3. vote 2 voice credits w/ original currently invalid key pair
+                // 3. vote w/ original currently invalid key pair
                 await letAllVotersVote(voterKeypairs, 1, undefined)
 
                 await timeTravel2EndOfVotingPeriod()
                 await tally()
                 const tallyResult = await getTallyResult()
 
-                const expected = [2, 1, 1] //  3rd vote should have been rejected
+                const expected = [3, 2, 1] //  3rd vote should have been rejected
                 const actual = tallyResult.slice(0, RECIPIENTS.length)
                 assert.deepEqual(actual, expected)
             })
@@ -311,23 +311,23 @@ contract('E2E', (accounts) => {
                 )
                 await letAllVoterSignUp2Maci(voterKeypairs)
 
-                // 1. vote 1 voice credit w/ original key pair
+                // 1. vote w/ original key pair
                 await letAllVotersVote(voterKeypairs, 3, undefined)
 
                 const newVoterKeypairs = [...Array(batchSize)].map(
                     (_) => new Keypair()
                 )
-                // 2. vote 1 voice credit w/ new key pair
+                // 2. vote w/ new key pair
                 await letAllVotersVote(voterKeypairs, 2, newVoterKeypairs)
 
-                // 3. vote 2 voice credit w/ current-valid key pair to override the previous vote
+                // 3. vote w/ current-valid key pair to override the previous vote
                 await letAllVotersVote(voterKeypairs, 1, newVoterKeypairs)
 
                 await timeTravel2EndOfVotingPeriod()
                 await tally()
                 const tallyResult = await getTallyResult()
 
-                const expected = [4, 2, 2] // 3rd vote should have been accepted
+                const expected = [3, 2, 1] // 3rd vote should have been accepted
                 const actual = tallyResult.slice(0, RECIPIENTS.length)
                 assert.deepEqual(actual, expected)
             })
@@ -359,19 +359,10 @@ contract('E2E', (accounts) => {
             const tallyResult = await getTallyResult()
 
             // coordinator withdraws deposits and transfer them to each recipient
+            const expected = [3, 2, 1]
             for (let i = 0; i < RECIPIENTS.length; i++) {
                 // coordinator transfer tokens voted to recipient currently owned by cream to recipient
-                const counts = tallyResult[i]
-                for (let j = 0; j < counts; j++) {
-                    const tx = await cream.withdraw(i, {
-                        from: coordinatorAddress,
-                    })
-                    truffleAssert.eventEmitted(tx, 'Withdrawal')
-                }
-
-                // check if number of token voted matches w/ recipient token balance
-                const numTokens = await votingToken.balanceOf(RECIPIENTS[i])
-                assert.equal(tallyResult[i], numTokens.toString())
+                assert.equal(tallyResult[i], expected[i])
             }
         })
     })

--- a/packages/contracts/test/E2E.Test.ts
+++ b/packages/contracts/test/E2E.Test.ts
@@ -68,7 +68,7 @@ contract('E2E', (accounts) => {
         const voiceCredit_1 = 2 // bnSqrt(BigNumber.from(2)) = 0x01, BigNumber
         const voiceCredit_2 = 4 // bnSqrt(BigNumber.from(4)) = 0x02, BigNumber
 
-        // weights for voter2, voter3, voter4, voter5
+        // weights for voter1, voter2, voter3, voter4
         const weights = [
             voiceCredit_1,
             voiceCredit_2,


### PR DESCRIPTION
This is the simple proposed solution to the issue #91. I implemented the weighted votes using voice credit. I know voice credit is supposed to be used for the different purpose like deciding each voter's preference, but it can be used for the weighted votes in the following way. Every voting period, exact 1 voting token is distributed for each voter by the contract owner. At the same time, the contract owner decides the weight of each voter (weight ranges from 1 to 100) and the weight is stored in the voting token contract as mapping of the voter's address. The voters votes later without caring about the weight, but the weight is recorded in the contract and the message is published with the weight automatically as the substitution to the voice credit. The tally result will be calculated based on the weight.

Note:
After implementing this, the withdraw function in the cream contract can not work as before. Once the weight is considered, mismatch between the number of voting token (1 voting token per voter) and the tally result (sqrt(weight) * voting) happens. Also, (sqrt(weight) * voting) tokens have to be transferred to recipients after the tally. I think this would cost much gas so better to use the tally result directly without executing withdraw function.